### PR TITLE
Add support for displaying social icons in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,12 @@
 {{- if not (.Param "hideFooter") }}
 <footer class="footer">
+    {{ if and (.Site.Params.SocialIconsFooter) (not .Params.HideSocialIconsFooter) }}
+        {{ if or (.Site.Params.SocialIconsFooterHome) (not .IsHome) }}
+            {{ if not (in .Site.Params.HideSocialIconsFooterSections .Section) }}
+                {{ partial "social_icons.html" $.Site.Params.socialIcons }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
     {{- if .Site.Copyright }}
     <span>{{ .Site.Copyright | markdownify }}</span>
     {{- else }}


### PR DESCRIPTION
This commit adds the following new options to the Site params:

* SocialIconsFooter
* SocialIconsFooterHome
* HideSocialIconsFooterSections:

The first one can be used to display social icons within the footer for
all pages except the homepage. The second one can be set to true to also
display social icons within the homepage. The last one is a list and can
be used to hide social icons on specific sections.

Furthermore, each page can include the page param HideSocialIconsFooter
to prevent social icons from being displayed within the footer.